### PR TITLE
Update dependencies/plugins - Eleventy v1.0.1 and eleventy-fetch v3.0.0

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,4 +1,4 @@
-const Cache = require("@11ty/eleventy-cache-assets");
+const Cache = require("@11ty/eleventy-fetch");
 
 // Get all post data
 const getPosts = async ({ url, key, version = "v4" }) => {

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Import your [Ghost](https://ghost.org) content directly into [Eleventy](https://github.com/11ty/eleventy) as global data.
 
-_Note: This plugin currently uses a development version of Eleventy which includes [`addGlobalData()`](https://www.11ty.dev/docs/data-global-custom/), tread carefully_
+_Note: This plugin requires Eleventy v1.0.0 or newer in order to take advantage of [`addGlobalData()`](https://www.11ty.dev/docs/data-global-custom/)_
 
 [See the live demo](https://eleventy-plugin-ghost.netlify.app) and the [demo directory in the repo](https://github.com/daviddarnes/eleventy-plugin-ghost/tree/main/demo) to see it all in action.
 
@@ -60,7 +60,7 @@ After installing and running you'll be provided with a global `ghost` key as wel
 - `ghost.authors`: An array of all authors in Ghost, including the number of posts within each author
 - `ghost.settings`: All settings set in Ghost
 
-All data is cached using [`@11ty/eleventy-cache-assets`](https://www.11ty.dev/docs/plugins/cache/) with a duration of 1 minute. This keeps the local builds fast while still inheriting newly applied content.
+All data is cached using [`@11ty/eleventy-fetch`](https://www.11ty.dev/docs/plugins/fetch/) with a duration of 1 minute. This keeps the local builds fast while still inheriting newly applied content.
 
 ### Internal tags
 

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,10 +1,10 @@
 {
   "scripts": {
-    "dev": "eleventy --serve",
-    "build": "eleventy"
+    "dev": "npx @11ty/eleventy --serve",
+    "build": "npx @11ty/eleventy"
   },
   "dependencies": {
-    "@11ty/eleventy": "^1.0.0-canary.41",
+    "@11ty/eleventy": "^1.0.1",
     "dotenv": "^8.2.0",
     "eleventy-plugin-ghost": "^1.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/daviddarnes/eleventy-plugin-ghost",
   "main": ".eleventy.js",
   "scripts": {
-    "build": "eleventy",
+    "build": "npx @11ty/eleventy",
     "bump": "npm --no-git-tag-version version"
   },
   "repository": {
@@ -30,7 +30,7 @@
     "url": "https://github.com/daviddarnes/eleventy-plugin-ghost/issues"
   },
   "dependencies": {
-    "@11ty/eleventy": "^1.0.0-canary.41",
-    "@11ty/eleventy-cache-assets": "^2.1.0"
+    "@11ty/eleventy": "^1.0.1",
+    "@11ty/eleventy-fetch": "^3.0.0"
   }
 }


### PR DESCRIPTION
@daviddarnes Alright this one is much cleaner with less commit noise 😄 I'll scrap the other one

- Update Eleventy to latest version (v1.0.1)
- Replace eleventy-cache-assets plugin with the newer [eleventy-fetch](https://www.11ty.dev/docs/plugins/fetch/) plugin
- Update Eleventy build/dev commands to use npx @11ty/eleventy as recommended by [docs](https://www.11ty.dev/docs/usage/)
- Update Readme file to reflect changes